### PR TITLE
add all/native/bytecode targets for all libraries

### DIFF
--- a/extlib/Makefile
+++ b/extlib/Makefile
@@ -9,9 +9,13 @@ MODULES = \
 MLI = $(MODULES:=.mli)
 SRC = $(MLI) $(MODULES:=.ml) extLib.ml
 
-all:
+all: bytecode native
+
+opt: native
+
+bytecode:
 	ocamlc -a -o extLib.cma $(SRC)
-opt:
+native:
 	ocamlopt -g -a -o extLib.cmxa $(SRC)
 doc:
 	ocamlc -c $(MODULES:=.mli)

--- a/javalib/Makefile
+++ b/javalib/Makefile
@@ -1,5 +1,9 @@
-all:
+all: bytecode native
+
+native:
 	ocamlopt -g -I ../extlib -a -o java.cmxa jData.ml jReader.ml
+bytecode:
+	ocamlc -g -I ../extlib -a -o java.cma jData.ml jReader.ml
 	
 clean:
 	rm -rf java.cmxa java.lib java.a $(wildcard *.cmx) $(wildcard *.obj) $(wildcard *.o) $(wildcard *.cmi)

--- a/neko/Makefile
+++ b/neko/Makefile
@@ -1,5 +1,9 @@
-all:
+all: bytecode native
+
+native:
 	ocamlopt -I ../extlib -a -o neko.cmxa nast.ml nxml.ml binast.ml nbytecode.ml ncompile.ml
+bytecode:
+	ocamlc -I ../extlib -a -o neko.cma nast.ml nxml.ml binast.ml nbytecode.ml ncompile.ml
 
 clean:
 	rm -rf neko.cmxa neko.lib neko.a $(wilcard *.cmx) $(wildcard *.obj) $(wildcard *.o) $(wildcard *.cmi)

--- a/swflib/Makefile
+++ b/swflib/Makefile
@@ -4,28 +4,47 @@
 
 CFLAGS= -I ../extlib -I ../extc -g
 LIBS=
-LFLAGS= -o swflib.cmxa -a
 
 MODULES=as3code.cmx png.cmx swf.cmx actionScript.cmx as3parse.cmx swfPic.cmx as3hlparse.cmx swfParser.cmx
 
-all: swflib.cmxa
+all: native bytecode
+
+native: swflib.cmxa
+
+bytecode: swflib.cma
 
 swflib.cmxa: $(MODULES)
-	ocamlopt $(LFLAGS) $(LIBS) $(MODULES)
+	ocamlopt -o swflib.cmxa -a $(LIBS) $(MODULES)
+
+
+swflib.cma: $(MODULES:.cmx=.cmo)
+	ocamlc -o swflib.cma -a $(LFLAGS) $(LIBS) $(MODULES:.cmx=.cmo)
 
 actionScript.cmx: swf.cmx
+
+as3code.cmo: as3.cmi
 
 as3code.cmx: as3.cmi
 
 as3hl.cmi: as3.cmi
 
+as3hlparse.cmo: as3parse.cmo as3hl.cmi as3code.cmo as3.cmi
+
 as3hlparse.cmx: as3parse.cmx as3hl.cmi as3code.cmx as3.cmi
+
+as3parse.cmo: as3code.cmo as3.cmi
 
 as3parse.cmx: as3code.cmx as3.cmi
 
+png.cmo: png.cmi
+
 png.cmx: png.cmi
 
+swf.cmo: as3.cmi
+
 swf.cmx: as3.cmi
+
+swfParser.cmo: swf.cmo as3parse.cmo actionScript.cmo
 
 swfParser.cmx: swf.cmx as3parse.cmx actionScript.cmx
 

--- a/ttflib/Makefile
+++ b/ttflib/Makefile
@@ -4,8 +4,13 @@ LIBS=extLib swflib unix
 
 OUTPUT=ttf
 
-all:
+all: native bytecode
+
+native:
 	ocamlopt $(FLAGS) $(FILES:=.ml) -g -a -o ttf.cmxa
+
+bytecode:
+	ocamlc $(FLAGS) $(FILES:=.ml) -g -a -o ttf.cma
 
 exec:
 	ocamlopt $(FLAGS) $(LIBS:=.cmxa) $(FILES:=.ml) main.ml -g -o $(OUTPUT)

--- a/xml-light/Makefile
+++ b/xml-light/Makefile
@@ -7,9 +7,13 @@ CFLAGS=
 LFLAGS= -a
 LIBS=
 
-all: xml-light.cma test.exe doc
+all: bytecode test.exe doc
 
-opt: xml-light.cmxa test_opt.exe
+opt: native
+
+native: xml-light.cmxa
+
+bytecode: xml-light.cma
 
 installcommon: all
 	cp xml.mli xmlParser.mli dtd.mli xml.cmi xmlParser.cmi dtd.cmi $(INSTALLDIR)

--- a/ziplib/Makefile
+++ b/ziplib/Makefile
@@ -1,5 +1,9 @@
-all:
+all: native bytecode
+
+native:
 	ocamlopt -g -I ../extlib -I ../extc -a -o zip.cmxa zlib.mli zlib.ml zip.mli zip.ml
+bytecode:
+	ocamlc -g -I ../extlib -I ../extc -a -o zip.cma zlib.mli zlib.ml zip.mli zip.ml
 	
 clean:
 	rm -rf zip.cmxa zip.lib zip.a $(wildcard *.cmx) $(wildcard *.obj) $(wildcard *.o) $(wildcard *.cmi)


### PR DESCRIPTION
This patch does not care about executables such as ttf.exe
