### PR TITLE
force new version

### DIFF
--- a/xml-light/README
+++ b/xml-light/README
@@ -1,4 +1,4 @@
-Xml-Light Version 2.2 :
+Xml-Light Version 2.3 :
 -----------------------
 
 Last version : http://tech.motion-twin.com


### PR DESCRIPTION
Several implementations are distributed with the same version number 2.2.
We force the move to 2.3 in order to have an unambiguous distribution.
