### PR TITLE
Fix for includes on FreeBSD

### DIFF
--- a/extc/process_stubs.c
+++ b/extc/process_stubs.c
@@ -35,7 +35,11 @@
 #	include <errno.h>
 #	include <string.h>
 #	ifndef __APPLE__
-#		include <wait.h>
+#		ifndef __FreeBSD__
+#			include <wait.h>
+#		else
+#			include <sys/wait.h>
+#		endif
 #	endif
 #endif
 


### PR DESCRIPTION
Added an ifdef that would change #include <wait.h> to #include <sys/wait.h> on FreeBSD. Closes #15 