### PR TITLE
Fix HaxeFoundation/haxe#5941.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# http://editorconfig.org
+
+[*.c]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+indent_brace_style = K&R
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 100

--- a/extc/extc_stubs.c
+++ b/extc/extc_stubs.c
@@ -161,7 +161,7 @@ static struct custom_operations zlib_stream_ops = {
  */
 value zlib_new_stream() {
     value z_streamp_val = caml_alloc_custom(&zlib_stream_ops, sizeof(z_streamp), 0, 1);
-    ZStreamP_val(z_streamp_val) = malloc(sizeof(z_stream));
+    ZStreamP_val(z_streamp_val) = caml_stat_alloc(sizeof(z_stream));
     ZStreamP_val(z_streamp_val)->zalloc = NULL;
     ZStreamP_val(z_streamp_val)->zfree = NULL;
     ZStreamP_val(z_streamp_val)->opaque = NULL;

--- a/extc/extc_stubs.c
+++ b/extc/extc_stubs.c
@@ -130,8 +130,8 @@ void zlib_free_stream(value z_streamp_val) {
 }
 
 /**
- * Define the custom operations for a z_stream. This ensures that the memory of the owned
- * by the contained pointer is freed.
+ * Define the custom operations for a z_stream. This ensures that the memory owned
+ * by the z_stream pointer is freed.
  *
  * See:
  * https://github.com/ocaml/ocaml/blob/70d880a41a82aae1ebd428fd38100e8467f8535a/byterun/caml/custom.h#L25


### PR DESCRIPTION
[The zlib issue](https://github.com/HaxeFoundation/haxe/issues/5941) was caused because the OCaml garbage collector moved the zlib data allocated on the heap while zlib kept backreference. This commit uses OCaml's custom memory allocation function to avoid this issue. This also adds a **.editorconfig** file for *.c and a few comments in **extc_stubs.c**.

References:
- https://github.com/HaxeFoundation/haxe/issues/5941
- https://github.com/xavierleroy/camlzip/pull/2