### PR TITLE
make ziplib -safe-string compatable

### DIFF
--- a/ziplib/Makefile
+++ b/ziplib/Makefile
@@ -6,11 +6,11 @@ all: native bytecode
 
 native: ziplib.cmxa
 ziplib.cmxa: $(SRC)
-	$(OCAMLOPT) -g -I ../extlib -I ../extc -a -o ziplib.cmxa $(SRC)
+	ocamlfind $(OCAMLOPT) -safe-string -g -I ../extlib -I ../extc -a -o ziplib.cmxa $(SRC)
 
 bytecode: ziplib.cma
 ziplib.cma: $(SRC)
-	$(OCAMLC) -g -I ../extlib -I ../extc -a -o ziplib.cma $(SRC)
+	ocamlfind $(OCAMLC) -safe-string -g -I ../extlib -I ../extc -a -o ziplib.cma $(SRC)
 
 clean:
 	rm -rf ziplib.cmxa ziplib.cma ziplib.lib ziplib.a $(wildcard *.cmx) $(wildcard *.obj) $(wildcard *.o) $(wildcard *.cmi) $(wildcard *.cmo)

--- a/ziplib/zlib.ml
+++ b/ziplib/zlib.ml
@@ -33,21 +33,21 @@ let crc_table = Array.init 256 (fun n ->
 let max_wbits = 15
 
 let compress ?(level = 6) ?(header = true) refill flush =
-  let inbuf = String.create buffer_size
-  and outbuf = String.create buffer_size in
+  let inbuf = Bytes.create buffer_size
+  and outbuf = Bytes.create buffer_size in
   let zs = Extc.zlib_deflate_init2 level (if header then max_wbits else -max_wbits) in
   let rec compr inpos inavail =
     if inavail = 0 then begin
       let incount = refill inbuf in
       if incount = 0 then compr_finish() else compr 0 incount
     end else begin
-      let res = Extc.zlib_deflate zs ~src:inbuf ~spos:inpos ~slen:inavail ~dst:outbuf ~dpos:0 ~dlen:buffer_size Z_NO_FLUSH in
+      let res = Extc.zlib_deflate zs ~src:(Bytes.to_string inbuf) ~spos:inpos ~slen:inavail ~dst:outbuf ~dpos:0 ~dlen:buffer_size Z_NO_FLUSH in
       let used_in, used_out = res.z_read, res.z_wrote in
       flush outbuf used_out;
       compr (inpos + used_in) (inavail - used_in)
     end
   and compr_finish () =
-    let ret = Extc.zlib_deflate zs ~src:inbuf ~spos:0 ~slen:0 ~dst:outbuf ~dpos:0 ~dlen:buffer_size Z_FINISH in
+    let ret = Extc.zlib_deflate zs ~src:(Bytes.to_string inbuf) ~spos:0 ~slen:0 ~dst:outbuf ~dpos:0 ~dlen:buffer_size Z_FINISH in
     let (finished, _, used_out) = ret.z_finish, ret.z_read, ret.z_wrote in
     flush outbuf used_out;
     if not finished then compr_finish()
@@ -56,12 +56,12 @@ let compress ?(level = 6) ?(header = true) refill flush =
     Extc.zlib_deflate_end zs
 
 let compress_direct  ?(level = 6) ?(header = true) flush =
-  let outbuf = String.create buffer_size in
+  let outbuf = Bytes.create buffer_size in
   let zs = Extc.zlib_deflate_init2 level (if header then max_wbits else -max_wbits) in
   let rec compr inbuf inpos inavail =
     if inavail = 0 then ()
     else begin
-      let res = Extc.zlib_deflate zs ~src:inbuf ~spos:inpos ~slen:inavail ~dst:outbuf ~dpos:0 ~dlen:buffer_size Z_NO_FLUSH in
+      let res = Extc.zlib_deflate zs ~src:(Bytes.to_string inbuf) ~spos:inpos ~slen:inavail ~dst:outbuf ~dpos:0 ~dlen:buffer_size Z_NO_FLUSH in
       let used_in, used_out = res.z_read, res.z_wrote in
       flush outbuf used_out;
       compr inbuf (inpos + used_in) (inavail - used_in)
@@ -75,15 +75,15 @@ let compress_direct  ?(level = 6) ?(header = true) flush =
   compr, compr_finish
 
 let uncompress ?(header = true) refill flush =
-  let inbuf = String.create buffer_size
-  and outbuf = String.create buffer_size in
+  let inbuf = Bytes.create buffer_size
+  and outbuf = Bytes.create buffer_size in
   let zs = Extc.zlib_inflate_init2 (if header then max_wbits else -max_wbits) in
   let rec uncompr inpos inavail =
     if inavail = 0 then begin
       let incount = refill inbuf in
       if incount = 0 then uncompr_finish true else uncompr 0 incount
     end else begin
-      let ret = Extc.zlib_inflate zs ~src:inbuf ~spos: inpos ~slen:inavail ~dst:outbuf ~dpos:0 ~dlen:buffer_size Z_SYNC_FLUSH in
+      let ret = Extc.zlib_inflate zs ~src:(Bytes.to_string inbuf) ~spos: inpos ~slen:inavail ~dst:outbuf ~dpos:0 ~dlen:buffer_size Z_SYNC_FLUSH in
       let (finished, used_in, used_out) = ret.z_finish, ret.z_read, ret.z_wrote in
       flush outbuf used_out;
       if not finished then uncompr (inpos + used_in) (inavail - used_in)
@@ -93,7 +93,7 @@ let uncompress ?(header = true) refill flush =
        after the compressed stream in order to complete decompression
        and return finished = true. *)
     let dummy_byte = if first_finish && not header then 1 else 0 in
-    let ret = Extc.zlib_inflate zs ~src:inbuf ~spos:0 ~slen:dummy_byte ~dst:outbuf ~dpos:0 ~dlen:buffer_size Z_SYNC_FLUSH in
+    let ret = Extc.zlib_inflate zs ~src:(Bytes.to_string inbuf) ~spos:0 ~slen:dummy_byte ~dst:outbuf ~dpos:0 ~dlen:buffer_size Z_SYNC_FLUSH in
     let (finished, _, used_out) = ret.z_finish, ret.z_read, ret.z_wrote in
     flush outbuf used_out;
     if not finished then uncompr_finish false
@@ -104,7 +104,7 @@ let uncompress ?(header = true) refill flush =
 let update_crc crc buf pos len =
   let c = ref (Int32.lognot crc) in
   for i = pos to (len + pos - 1) do
-    let b = Int32.of_int (int_of_char (String.get buf i)) in
+    let b = Int32.of_int (int_of_char (Bytes.get buf i)) in
     c := Int32.logxor (Array.get crc_table (Int32.to_int (Int32.logand (Int32.logxor !c b) 0xFFl))) (Int32.shift_right_logical !c 8);
   done;
   let ret = Int32.lognot !c in

--- a/ziplib/zlib.mli
+++ b/ziplib/zlib.mli
@@ -16,14 +16,14 @@
 
 val compress:
   ?level: int -> ?header: bool -> 
-  (string -> int) -> (string -> int -> unit) -> unit
+  (bytes -> int) -> (bytes -> int -> unit) -> unit
 
 val compress_direct:
-  ?level: int -> ?header: bool -> (string -> int -> unit) ->
-  (string -> int -> int -> unit) * (unit -> unit)
+  ?level: int -> ?header: bool -> (bytes -> int -> unit) ->
+  (bytes -> int -> int -> unit) * (unit -> unit)
 
 val uncompress:
-  ?header: bool -> (string -> int) -> (string -> int -> unit) -> unit
+  ?header: bool -> (bytes -> int) -> (bytes -> int -> unit) -> unit
 
 val update_crc: 
-  int32 -> string -> int -> int -> int32
+  int32 -> bytes -> int -> int -> int32


### PR DESCRIPTION
Although it compiles and the haxe unit test passed for the flash target, I still would like to have some review. Particularly, I guess `Bytes.unsafe_to_string` can be used in place of some occurrences of `Bytes.to_string` for better performance.

Fix https://github.com/HaxeFoundation/haxe/issues/6749.