### PR TITLE
kill(2) needs <signal.h> according to POSIX

### DIFF
--- a/extc/process_stubs.c
+++ b/extc/process_stubs.c
@@ -31,6 +31,7 @@
 #	include <windows.h>
 #else
 #	include <sys/types.h>
+#	include <signal.h>
 #	include <unistd.h>
 #	include <errno.h>
 #	include <string.h>


### PR DESCRIPTION
Otherwise clang complains